### PR TITLE
Add support to edit quotes from CMS

### DIFF
--- a/public/config.yml
+++ b/public/config.yml
@@ -89,3 +89,22 @@ collections:
             fields:
               - { name: "key", label: "Key", widget: "string" }
               - { name: "value", label: "Value", widget: "string" }
+  - label: "Quotes"
+    description: "Shown on pauseai.info/quotes"
+    name: "quotes"
+    files:
+      - label: "PauseAI Quotes"
+        name: "pauseai"
+        file: "src/routes/quotes/data.json"
+        fields:
+          - label: Quotes
+            name: quotes
+            widget: list
+            fields:
+              - { name: "background", label: "Background", widget: "string" }
+              - { name: "color", label: "Color", widget: "string", required: false }
+              - { name: "text", label: "Text", widget: "string" }
+              - { name: "author", label: "Author", widget: "string" }
+              - { name: "author_description", label: "Author Description", widget: "string" }
+              - { name: "padding", label: "Padding", widget: "string", required: false }
+              - { name: "notice", label: "Notice", widget: "string", required: false }


### PR DESCRIPTION
### Notes

Added support for managing quotes page (https://pauseai.info/quotes) with CMS. Issue - https://github.com/PauseAI/pauseai-cms/issues/1

It follows the same approach as is done for managing the communities page.

Note - This should be merged after https://github.com/PauseAI/pauseai-website/pull/360 is merged and deployed.

### Testing

https://github.com/user-attachments/assets/0057239e-539d-4b46-856f-ffed622f43ec